### PR TITLE
Add search bar with Radarr/Sonarr results

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The purpose of ShowNotes is to be a tool for exploring tv show, season and chara
 - Run `npx tailwindcss -i ./app/static/input.css -o ./app/static/admin_settings.css --minify` after making changes to templates or Tailwind config.
 
 ### Local Poster Caching
-- Caches Sonarr and Radarr poster images locally in `/app/static/posters` for improved performance and reliability.
+- Caches Sonarr and Radarr poster images locally in `/app/static/poster` for improved performance and reliability.
+- Background images are stored in `/app/static/background` when available.
 - Poster cache is updated via Plex webhook events.
 
 ### Admin Settings UI Improvements

--- a/app/static/search.js
+++ b/app/static/search.js
@@ -1,0 +1,27 @@
+// Search bar functionality
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    const input = document.getElementById('search-input');
+    const results = document.getElementById('search-results');
+    if(!input || !results) return;
+    let controller;
+    input.addEventListener('input', async function(){
+      const q = this.value.trim();
+      if(controller){ controller.abort(); }
+      if(!q){ results.classList.add('hidden'); results.innerHTML=''; return; }
+      controller = new AbortController();
+      try{
+        const resp = await fetch('/search?q=' + encodeURIComponent(q), {signal: controller.signal});
+        if(!resp.ok) throw new Error('search failed');
+        const data = await resp.json();
+        results.innerHTML = data.map(item => `<div class="p-2 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700">${item.title}</div>`).join('');
+        results.classList.remove('hidden');
+      }catch(e){ if(e.name!=='AbortError') console.error(e); }
+    });
+    document.addEventListener('click', (e)=>{
+      if(!results.contains(e.target) && e.target!==input){
+        results.classList.add('hidden');
+      }
+    });
+  });
+})();

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -5,18 +5,23 @@
 {% block head %}
   <link rel="stylesheet" href="{{ url_for('static', filename='admin_settings.css') }}">
   <script src="{{ url_for('static', filename='darkmode.js') }}" defer></script>
+  <script src="{{ url_for('static', filename='search.js') }}" defer></script>
   {# Only include admin_settings.js if needed (e.g., on admin pages) #}
   {% block extra_js %}{% endblock %}
 {% endblock %}
 
 {% block content %}
 <header class="bg-gray-800 text-white dark:bg-gray-900 dark:text-gray-100 p-4">
-  <div class="container mx-auto flex items-center justify-between">
-    <div>
+  <div class="container mx-auto flex items-center space-x-4">
+    <div class="flex-shrink-0">
       {% block header %}
       <h1 class="text-xl">ShowNotes</h1>
       {% endblock %}
     </div>
+    <form id="search-form" class="flex-1 relative">
+      <input id="search-input" type="text" placeholder="Search shows and movies" class="w-full px-2 py-1 text-sm rounded text-gray-900" autocomplete="off">
+      <div id="search-results" class="absolute left-0 right-0 mt-1 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-lg rounded z-50 hidden"></div>
+    </form>
     <button id="darkmode-toggle" title="Toggle light/dark mode" class="focus:outline-none p-2 rounded-full bg-gray-700 hover:bg-gray-600 transition-colors">
       <!-- Icon is set by JS -->
     </button>


### PR DESCRIPTION
## Summary
- add search bar and JS to fetch titles from Sonarr/Radarr
- store cached posters in `/app/static/poster` and backdrops in `/app/static/background`
- add `/search` endpoint using Radarr and Sonarr APIs
- document new static directories

## Testing
- `python3 -m py_compile app/routes.py app/database.py app/__init__.py run.py`

------
https://chatgpt.com/codex/tasks/task_e_6843b78d87548321ab1ef3e23f654059