### PR TITLE
Add Tautulli integration and new admin tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ The purpose of ShowNotes is to be a tool for exploring tv show, season and chara
 - **Image Loading:** Updated image loading strategy to use locally cached images (posters and backgrounds) served from `/static/poster/` and `/static/background/` respectively, with filenames based on TMDB IDs. Image queuing for Sonarr and Radarr syncs now prepares files for this local cache.
 - **Show Detail Page:** Significantly enhanced the Show Detail page with a new Sonarr-like layout including a background image, detailed metadata (first air date, status, next episode, IMDb link), collapsible season/episode lists, and display of the 'currently watched' episode based on Plex activity.
 - **Homepage Layout:** Revamped the homepage to prominently display the 'currently playing/paused' item and a grid of 'previously watched' items, derived from Plex activity.
-- **Tautulli Stubs:** Added initial stubs for future Tautulli integration, including settings in the admin panel and a placeholder for Tautulli watch history sync.
+- **Tautulli Integration:** Completed support for syncing watch history from Tautulli with connection testing.
+- **Episode Pages:** Episodes are now clickable from show details and the homepage.
+- **Collapsible Service Cards:** All service settings on the admin page start collapsed for easier navigation.
+- **Admin Logbook:** New logbook section summarizing sync operations and Plex activity.
+- **User List:** Admins can view Plex users, last login times, and latest watched items.
 
 ### Admin Panel & Service Management
 - **Dynamic Service Status:** The admin services page (`/admin/settings`) now features real-time status indicators.

--- a/app/cli.py
+++ b/app/cli.py
@@ -57,14 +57,17 @@ def process_image_queue(limit, delay, max_attempts):
 
     click.echo(f"Found {len(tasks)} images to process.")
 
-    cache_dir_base = os.path.join(current_app.static_folder, 'poster_cache') # Matches image_proxy
-    os.makedirs(cache_dir_base, exist_ok=True)
+    poster_dir = os.path.join(current_app.static_folder, 'poster')
+    background_dir = os.path.join(current_app.static_folder, 'background')
+    os.makedirs(poster_dir, exist_ok=True)
+    os.makedirs(background_dir, exist_ok=True)
 
     for task in tasks:
         task_id = task['id']
         image_url = task['image_url']
         target_filename = task['target_filename']
-        item_type = task['item_type'] # 'show' or 'movie'
+        item_type = task['item_type']  # 'show' or 'movie'
+        image_kind = task['image_kind']
 
         click.echo(f"Processing task ID {task_id}: {image_url} -> {target_filename}")
 
@@ -113,7 +116,12 @@ def process_image_queue(limit, delay, max_attempts):
             response = requests.get(image_url, stream=True, headers=headers, timeout=20) # Increased timeout for downloads
             response.raise_for_status() # Raise HTTPError for bad responses (4xx or 5xx)
 
-            image_path = os.path.join(cache_dir_base, target_filename)
+            if image_kind == 'background':
+                dest_dir = background_dir
+            else:
+                dest_dir = poster_dir
+
+            image_path = os.path.join(dest_dir, target_filename)
 
             with open(image_path, 'wb') as f:
                 for chunk in response.iter_content(chunk_size=8192):

--- a/app/migrations/008_add_tautulli_columns.py
+++ b/app/migrations/008_add_tautulli_columns.py
@@ -1,0 +1,18 @@
+import sqlite3, os
+
+DB_PATH = os.environ.get('SHOWNOTES_DB', 'instance/shownotes.sqlite3')
+
+def upgrade():
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(settings)")
+    cols = [r[1] for r in cur.fetchall()]
+    if 'tautulli_url' not in cols:
+        cur.execute("ALTER TABLE settings ADD COLUMN tautulli_url TEXT")
+    if 'tautulli_api_key' not in cols:
+        cur.execute("ALTER TABLE settings ADD COLUMN tautulli_api_key TEXT")
+    conn.commit()
+    conn.close()
+
+if __name__ == '__main__':
+    upgrade()

--- a/app/migrations/009_add_last_login_to_users.py
+++ b/app/migrations/009_add_last_login_to_users.py
@@ -1,0 +1,16 @@
+import sqlite3, os
+
+DB_PATH = os.environ.get('SHOWNOTES_DB', 'instance/shownotes.sqlite3')
+
+def upgrade():
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(users)")
+    cols = [r[1] for r in cur.fetchall()]
+    if 'last_login_at' not in cols:
+        cur.execute("ALTER TABLE users ADD COLUMN last_login_at DATETIME")
+    conn.commit()
+    conn.close()
+
+if __name__ == '__main__':
+    upgrade()

--- a/app/static/admin_settings.js
+++ b/app/static/admin_settings.js
@@ -62,6 +62,9 @@ function bindTests() {
         key = document.getElementById('bazarr_api_key').value;
       } else if (service === 'ollama') {
         url = document.getElementById('ollama_url').value;
+      } else if (service === 'tautulli') {
+        url = document.getElementById('tautulli_url').value;
+        key = document.getElementById('tautulli_api_key').value;
       }
       
       fetch('/admin/test-api', {

--- a/app/templates/admin_layout.html
+++ b/app/templates/admin_layout.html
@@ -50,13 +50,17 @@
                 <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.33 12.048c.29-.28.47-.662.47-1.082a2.083 2.083 0 00-2.083-2.083c-.42 0-.792.174-1.07.456M12 14.5v.01M9.663 9.01L12 11.5l2.337-2.49M12 14.5a2.5 2.5 0 002.5-2.5V9.5a2.5 2.5 0 10-5 0v2.5a2.5 2.5 0 002.5 2.5z"></path></svg>
                 LLM Prompts <span class="ml-auto text-xs">(Soon)</span>
             </a>
-            <a href="#" class="flex items-center px-2 py-2 rounded-md hover:bg-slate-700 hover:text-white">
+            <a href="{{ url_for('admin.users_list') }}" class="flex items-center px-2 py-2 rounded-md hover:bg-slate-700 hover:text-white {% if request.endpoint == 'admin.users_list' %}bg-slate-700 text-white{% else %}text-gray-400{% endif %}">
                  <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 016-6h6M21 13.5A4.5 4.5 0 1116.5 9 4.5 4.5 0 0121 13.5z"></path></svg>
-                Users <span class="ml-auto text-xs">(Soon)</span>
+                Users
             </a>
             <a href="{{ url_for('admin.logs_view') }}" class="flex items-center px-2 py-2 rounded-md hover:bg-slate-700 hover:text-white {% if request.endpoint == 'admin.logs_view' %}bg-slate-700 text-white{% else %}text-gray-400{% endif %}">
                 <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
                 Logs
+            </a>
+            <a href="{{ url_for('admin.logbook_view') }}" class="flex items-center px-2 py-2 rounded-md hover:bg-slate-700 hover:text-white {% if request.endpoint == 'admin.logbook_view' %}bg-slate-700 text-white{% else %}text-gray-400{% endif %}">
+                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4M4 7l8 5 8-5"></path></svg>
+                Logbook
             </a>
              <a href="#" class="flex items-center px-2 py-2 rounded-md hover:bg-slate-700 hover:text-white">
                 <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.755 4 3.92C16 12.862 14.713 14 12.995 14c-1.406 0-2.657-.936-3.104-2.186M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 17.625V18.5A1.5 1.5 0 0110.5 20h-1A1.5 1.5 0 018 18.5v-.875M12 3.5V2.625A1.5 1.5 0 0010.5 1h-1A1.5 1.5 0 008 2.625V3.5m0 13.125V18.5A1.5 1.5 0 009.5 20h1a1.5 1.5 0 001.5-1.5v-.875M12 3.5V2.625A1.5 1.5 0 0111.5 1h1A1.5 1.5 0 0114 2.625V3.5M4.5 10.5a7.5 7.5 0 1115 0v3a7.5 7.5 0 01-7.5 7.5h-1.5a7.5 7.5 0 01-6-7.5v-3z"></path></svg>

--- a/app/templates/admin_logbook.html
+++ b/app/templates/admin_logbook.html
@@ -1,0 +1,39 @@
+{% extends "admin_layout.html" %}
+{% block admin_page_title %}Logbook{% endblock %}
+{% block admin_page_header %}Logbook{% endblock %}
+{% block admin_page_content %}
+<div class="space-y-8">
+  <div>
+    <form method="get" class="mb-4">
+      <label class="mr-2">Category:</label>
+      <select name="category" onchange="this.form.submit()" class="border rounded px-2 py-1">
+        <option value="" {% if not category %}selected{% endif %}>All</option>
+        <option value="sync" {% if category=='sync' %}selected{% endif %}>Service Sync</option>
+        <option value="plex" {% if category=='plex' %}selected{% endif %}>Plex Events</option>
+      </select>
+    </form>
+  </div>
+  {% if not category or category in ['sync','all'] %}
+  <div>
+    <h2 class="text-xl font-semibold mb-2">Service Sync Events</h2>
+    <table class="min-w-full text-sm">
+      <tr class="font-bold text-left"><th class="pr-4">Service</th><th class="pr-4">Status</th><th>Last Attempt</th></tr>
+      {% for row in sync_logs %}
+      <tr class="border-t"><td>{{ row.service_name }}</td><td>{{ row.status }}</td><td>{{ row.last_attempted_sync_at }}</td></tr>
+      {% endfor %}
+    </table>
+  </div>
+  {% endif %}
+  {% if not category or category in ['plex','all'] %}
+  <div>
+    <h2 class="text-xl font-semibold mb-2">Recent Plex Activity</h2>
+    <table class="min-w-full text-sm">
+      <tr class="font-bold text-left"><th class="pr-4">User</th><th class="pr-4">Event</th><th class="pr-4">Title</th><th>Time</th></tr>
+      {% for row in plex_logs %}
+      <tr class="border-t"><td>{{ row.plex_username }}</td><td>{{ row.event_type }}</td><td>{{ row.title }}</td><td>{{ row.event_timestamp|format_datetime }}</td></tr>
+      {% endfor %}
+    </table>
+  </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/app/templates/admin_settings.html
+++ b/app/templates/admin_settings.html
@@ -13,33 +13,36 @@
 <form method="post" class="space-y-8 max-w-2xl mx-auto">
   <!-- Service Settings Group -->
     <!-- Ollama -->
-    <div class="bg-slate-100 dark:bg-slate-800 shadow-lg rounded-lg p-4 sm:p-6">
-      <div class="flex items-center gap-x-3 mb-2">
+    <details class="bg-slate-100 dark:bg-slate-800 shadow-lg rounded-lg p-4 sm:p-6" >
+      <summary class="flex items-center gap-x-3 cursor-pointer">
         <span class="inline-block w-12 h-12 sm:w-14 sm:h-14">
           <img src="{{ url_for('static', filename='logos/ollama-light.png') }}" alt="Ollama logo" class="w-full h-full object-contain dark:hidden">
           <img src="{{ url_for('static', filename='logos/ollama-dark.png') }}" alt="Ollama logo dark" class="w-full h-full object-contain hidden dark:inline">
         </span>
         <span class="font-semibold text-xl text-slate-800 dark:text-slate-100">Ollama</span>
         <span id="ollama_status_dot" class="ml-2 {% if ollama_status %}text-green-500{% else %}text-red-500{% endif %}" title="{% if ollama_status %}Connected{% else %}Not Connected/Error{% endif %}">●</span>
+      </summary>
+      <div class="mt-4">
+        <p class="text-slate-500 dark:text-slate-400 text-sm mb-4">Ollama provides AI-powered features for enhanced automation and recommendations.</p>
+        <label class="block text-sm font-medium text-slate-700 dark:text-slate-200 mb-1" for="ollama_url">URL</label>
+        <input type="text" id="ollama_url" name="ollama_url" value="{{ settings.ollama_url }}" class="border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 text-slate-900 dark:text-slate-50 rounded-lg p-2 w-full focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500">
+        <button type="button" data-service="ollama" class="test-btn bg-sky-500 hover:bg-sky-600 text-white px-4 py-2 rounded-md shadow-sm mt-3 text-sm font-medium">Test</button>
       </div>
-      <p class="text-slate-500 dark:text-slate-400 text-sm mb-4">Ollama provides AI-powered features for enhanced automation and recommendations.</p>
-      <label class="block text-sm font-medium text-slate-700 dark:text-slate-200 mb-1" for="ollama_url">URL</label>
-      <input type="text" id="ollama_url" name="ollama_url" value="{{ settings.ollama_url }}" class="border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 text-slate-900 dark:text-slate-50 rounded-lg p-2 w-full focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500">
-      <button type="button" data-service="ollama" class="test-btn bg-sky-500 hover:bg-sky-600 text-white px-4 py-2 rounded-md shadow-sm mt-3 text-sm font-medium">Test</button>
-    </div>
+    </details>
 
     <!-- Plex OAuth Settings -->
-    <div class="bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-400 dark:border-yellow-600 shadow-lg rounded-lg p-4 sm:p-6 mb-8">
-      <div class="flex items-center gap-x-3 mb-3">
+    <details class="bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-400 dark:border-yellow-600 shadow-lg rounded-lg p-4 sm:p-6 mb-8">
+      <summary class="flex items-center gap-x-3 cursor-pointer">
         <span class="inline-block w-12 h-12 sm:w-14 sm:h-14">
           <img src="{{ url_for('static', filename='logos/plex-light.png') }}" alt="Plex logo" class="w-full h-full object-contain dark:hidden">
           <img src="{{ url_for('static', filename='logos/plex-dark.png') }}" alt="Plex logo dark" class="w-full h-full object-contain hidden dark:inline">
         </span>
         <h3 class="text-xl font-bold text-yellow-700 dark:text-yellow-400">Plex OAuth Authentication</h3>
-      </div>
-      <div class="text-sm text-yellow-800 dark:text-yellow-300 mb-4">
-        <p>Set up Plex OAuth to enable user authentication with Plex accounts. You do <strong>not</strong> need to register your app with Plex—just use a unique Client ID for your app. See <a href="https://forums.plex.tv/t/authenticating-with-plex/609370" class="text-sky-600 dark:text-sky-400 underline" target="_blank">Plex OAuth Guide</a> for details.</p>
-      </div>
+      </summary>
+      <div class="mt-4">
+        <div class="text-sm text-yellow-800 dark:text-yellow-300 mb-4">
+          <p>Set up Plex OAuth to enable user authentication with Plex accounts. You do <strong>not</strong> need to register your app with Plex—just use a unique Client ID for your app. See <a href="https://forums.plex.tv/t/authenticating-with-plex/609370" class="text-sky-600 dark:text-sky-400 underline" target="_blank">Plex OAuth Guide</a> for details.</p>
+        </div>
       <div class="space-y-4">
         <div>
           <label class="block text-sm font-medium text-slate-700 dark:text-slate-200 mb-1" for="plex_client_id">
@@ -63,18 +66,20 @@
           }
         });
       </script>
-    </div>
+      </div>
+    </details>
 
     <!-- Pushover -->
-    <div class="bg-slate-100 dark:bg-slate-800 shadow-lg rounded-lg p-4 sm:p-6">
-      <div class="flex items-center gap-x-3 mb-2">
+    <details class="bg-slate-100 dark:bg-slate-800 shadow-lg rounded-lg p-4 sm:p-6">
+      <summary class="flex items-center gap-x-3 cursor-pointer">
         <span class="inline-block w-12 h-12 sm:w-14 sm:h-14">
           <img src="{{ url_for('static', filename='logos/pushover-light.png') }}" alt="Pushover logo" class="w-full h-full object-contain dark:hidden">
           <img src="{{ url_for('static', filename='logos/pushover-dark.png') }}" alt="Pushover logo dark" class="w-full h-full object-contain hidden dark:inline">
         </span>
         <span class="font-semibold text-xl text-slate-800 dark:text-slate-100">Pushover</span>
         <span id="pushover_status" class="ml-auto text-sm text-slate-600 dark:text-slate-300"></span>
-      </div>
+      </summary>
+      <div class="mt-4">
       <p class="text-slate-500 dark:text-slate-400 text-sm mb-4">Pushover sends notifications to your device when important events occur.</p>
       <div class="space-y-3">
         <div>
@@ -90,11 +95,12 @@
         </div>
       </div>
       <button type="button" id="pushover-test-btn" class="bg-sky-500 hover:bg-sky-600 text-white px-4 py-2 rounded-md shadow-sm mt-4 text-sm font-medium">Send Test Notification</button>
-    </div>
+      </div>
+    </details>
 
     <!-- Tautulli -->
-    <div class="bg-slate-100 dark:bg-slate-800 shadow-lg rounded-lg p-4 sm:p-6">
-      <div class="flex items-center gap-x-3 mb-2">
+    <details class="bg-slate-100 dark:bg-slate-800 shadow-lg rounded-lg p-4 sm:p-6">
+      <summary class="flex items-center gap-x-3 cursor-pointer">
         <span class="inline-block w-12 h-12 sm:w-14 sm:h-14">
           {# Placeholder for Tautulli logo - assuming a tautulli.png might exist or be added later #}
           <img src="{{ url_for('static', filename='logos/tautulli-light.png') }}" alt="Tautulli logo" class="w-full h-full object-contain dark:hidden">
@@ -102,7 +108,8 @@
         </span>
         <span class="font-semibold text-xl text-slate-800 dark:text-slate-100">Tautulli</span>
         <span id="tautulli_status_dot" class="ml-2 {% if tautulli_status %}text-green-500{% else %}text-red-500{% endif %}" title="{% if tautulli_status %}Connected{% else %}Not Connected/Error{% endif %}">●</span>
-      </div>
+      </summary>
+      <div class="mt-4">
       <p class="text-slate-500 dark:text-slate-400 text-sm mb-4">Tautulli provides detailed Plex media server statistics and watch history.</p>
       <div class="space-y-3">
         <div>
@@ -115,10 +122,12 @@
         </div>
       </div>
       <button type="button" data-service="tautulli" class="test-btn bg-sky-500 hover:bg-sky-600 text-white px-4 py-2 rounded-md shadow-sm mt-4 text-sm font-medium">Test</button>
-    </div>
+      </div>
+    </details>
 
     <!-- Sonarr, Radarr, Bazarr Grouped Card -->
-    <div class="bg-slate-100 dark:bg-slate-800 shadow-lg rounded-lg p-4 sm:p-6">
+    <details class="bg-slate-100 dark:bg-slate-800 shadow-lg rounded-lg p-4 sm:p-6">
+      <summary class="flex items-center gap-x-3 cursor-pointer font-semibold text-xl text-slate-800 dark:text-slate-100">Sonarr / Radarr / Bazarr</summary>
       <!-- Sonarr -->
       <div class="mb-6 sm:mb-8">
         <div class="flex items-center gap-x-3 mb-2">
@@ -205,7 +214,7 @@
         </div>
         <button type="button" data-service="bazarr" class="test-btn bg-sky-500 hover:bg-sky-600 text-white px-4 py-2 rounded-md shadow-sm mt-4 text-sm font-medium">Test</button>
       </div>
-    </div>
+    </details>
   <button type="submit" class="w-full sm:w-auto bg-green-600 hover:bg-green-700 text-white px-8 py-3 rounded-lg shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-opacity-50 transition-all duration-150 ease-in-out text-base font-semibold mt-8 flex items-center justify-center">Save Changes</button>
 </form>
 

--- a/app/templates/admin_tasks.html
+++ b/app/templates/admin_tasks.html
@@ -62,14 +62,14 @@
             <h2 class="text-2xl font-semibold text-gray-800 dark:text-gray-200">Tautulli Sync</h2>
         </div>
         <p class="text-gray-600 dark:text-gray-400 mb-6">
-            Manually trigger a synchronization of watch history from Tautulli. (Functionality not yet implemented)
+            Manually trigger a synchronization of watch history from Tautulli.
         </p>
-        <form action="{{ url_for('admin.sync_tautulli_placeholder') }}" method="POST">
+        <form action="{{ url_for('admin.sync_tautulli') }}" method="POST">
             <button type="submit" class="w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-3 px-6 rounded-lg shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-orange-400 focus:ring-opacity-50 transform transition-all duration-200 ease-in-out flex items-center justify-center">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m-15.357-2a8.001 8.001 0 0015.357 2M9 15h4.581" />
                 </svg>
-                Sync Tautulli Watch History (Placeholder)
+                Sync Tautulli Watch History
             </button>
         </form>
     </div>

--- a/app/templates/admin_users.html
+++ b/app/templates/admin_users.html
@@ -1,0 +1,23 @@
+{% extends "admin_layout.html" %}
+{% block admin_page_title %}Users{% endblock %}
+{% block admin_page_header %}Users{% endblock %}
+{% block admin_page_content %}
+<table class="min-w-full text-sm">
+  <tr class="font-bold text-left"><th class="pr-4">Avatar</th><th class="pr-4">Username</th><th class="pr-4">Last Login</th><th>Last Watched</th></tr>
+  {% for user in users %}
+  <tr class="border-t">
+    <td class="py-1">
+      {% if user.plex_user_id and plex_token %}
+      <img src="https://plex.tv/users/{{ user.plex_user_id }}/avatar?token={{ plex_token }}" class="h-8 w-8 rounded-full"/>
+      {% endif %}
+    </td>
+    <td>{{ user.username }}</td>
+    <td>{{ user.last_login_at or 'N/A' }}</td>
+    <td>
+      {% set latest = user_latest.get(user.id) %}
+      {% if latest %}{{ latest.season_episode }} {{ latest.title }}{% else %}N/A{% endif %}
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/episode_detail.html
+++ b/app/templates/episode_detail.html
@@ -1,0 +1,21 @@
+{% extends "layout.html" %}
+{% block title %}{{ show.title }} - {{ episode.title }}{% endblock %}
+{% block page_content %}
+<div class="bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
+  <div class="relative bg-cover bg-center py-12" style="{% if show.fanart_url %}background-image: url('/static/background/{{ show.tmdb_id }}.jpg');{% else %}background-color:#1a202c;{% endif %}">
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"></div>
+    <div class="relative max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="md:flex md:items-start md:space-x-8">
+        <div class="flex-shrink-0 w-40 sm:w-48 md:w-56 mx-auto md:mx-0 mb-6 md:mb-0">
+          <img src="/static/poster/{{ show.tmdb_id }}.jpg" alt="Poster" class="rounded-lg shadow-2xl w-full aspect-[2/3] object-cover" onerror="this.onerror=null; this.src='{{ url_for('static', filename='img/placeholder_poster.png') }}';">
+        </div>
+        <div class="text-center md:text-left flex-grow">
+          <h1 class="text-3xl font-extrabold text-white mb-2">{{ show.title }} - {{ episode.title }}</h1>
+          <p class="text-gray-300 mb-4">Season {{ season_number }} Episode {{ episode.episode_number }}</p>
+          <p class="text-gray-200">{{ episode.overview or 'No overview available.' }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -35,7 +35,9 @@
                 {{ current_plex_event.title }} {# This is Show Title from _get_plex_event_details #}
               </a>
               <p class="text-md sm:text-lg font-semibold text-slate-700 dark:text-slate-200 mb-1 truncate" title="{{ current_plex_event.episode_title }}">
-                {{ current_plex_event.season_episode }}: {{ current_plex_event.episode_title }}
+                <a href="{{ current_plex_event.episode_detail_url }}" class="hover:underline">
+                  {{ current_plex_event.season_episode }}: {{ current_plex_event.episode_title }}
+                </a>
               </p>
             {% elif current_plex_event.item_type_for_url == 'movie' and current_plex_event.link_tmdb_id %}
               <a href="{{ url_for('main.movie_detail', tmdb_id=current_plex_event.link_tmdb_id) }}"
@@ -97,7 +99,9 @@
                    <a href="{{ url_for('main.show_detail', tmdb_id=item.link_tmdb_id) }}" class="font-semibold text-sm text-slate-700 dark:text-slate-200 hover:text-sky-500 dark:hover:text-sky-400 block truncate" title="{{ item.title }}">
                     {{ item.title }} {# Show Title #}
                   </a>
-                  <p class="text-xs text-slate-500 dark:text-slate-400 truncate" title="{{ item.episode_title }}">{{ item.season_episode }}: {{ item.episode_title }}</p>
+                  <p class="text-xs text-slate-500 dark:text-slate-400 truncate" title="{{ item.episode_title }}">
+                    <a href="{{ item.episode_detail_url }}" class="hover:underline">{{ item.season_episode }}: {{ item.episode_title }}</a>
+                  </p>
                 {% elif item.item_type_for_url == 'movie' and item.link_tmdb_id %}
                   <a href="{{ url_for('main.movie_detail', tmdb_id=item.link_tmdb_id) }}" class="font-semibold text-sm text-slate-700 dark:text-slate-200 hover:text-sky-500 dark:hover:text-sky-400 block truncate" title="{{ item.title }}">
                     {{ item.title }}

--- a/app/templates/show_detail.html
+++ b/app/templates/show_detail.html
@@ -81,7 +81,9 @@
             <div class="bg-slate-800/70 backdrop-blur-md p-4 rounded-lg shadow-lg">
                 <h3 class="text-lg font-semibold text-sky-400 mb-2">Currently Watching</h3>
                 <p class="text-gray-200">
-                    {{ currently_watched_episode_info.season_episode }}: {{ currently_watched_episode_info.title }}
+                    <a href="{{ url_for('main.episode_detail', tmdb_id=show.tmdb_id, season_number=currently_watched_episode_info.season_episode[1:3]|int, episode_number=currently_watched_episode_info.season_episode[4:6]|int) }}" class="hover:underline">
+                        {{ currently_watched_episode_info.season_episode }}: {{ currently_watched_episode_info.title }}
+                    </a>
                 </p>
                 {% if currently_watched_episode_info.progress_percent is defined %}
                 <div class="w-full bg-gray-600 rounded-full h-2.5 mt-2">
@@ -89,6 +91,15 @@
                 </div>
                 <p class="text-xs text-gray-400 text-right">{{ currently_watched_episode_info.progress_percent }}% watched (approx.)</p>
                 {% endif %}
+            </div>
+            {% elif last_watched_episode_info %}
+            <div class="bg-slate-800/70 backdrop-blur-md p-4 rounded-lg shadow-lg">
+                <h3 class="text-lg font-semibold text-sky-400 mb-2">Last Watched</h3>
+                <p class="text-gray-200">
+                    <a href="{{ url_for('main.episode_detail', tmdb_id=show.tmdb_id, season_number=last_watched_episode_info.season_episode[1:3]|int, episode_number=last_watched_episode_info.season_episode[4:6]|int) }}" class="hover:underline">
+                        {{ last_watched_episode_info.season_episode }}: {{ last_watched_episode_info.title }}
+                    </a>
+                </p>
             </div>
             {% endif %}
         </div>
@@ -115,7 +126,9 @@
                                         <div class="flex justify-between items-start">
                                             <div>
                                                 <h4 class="font-medium text-gray-800 dark:text-gray-100">
-                                                    {{ episode.episode_number }}. {{ episode.title | default('TBA') }}
+                                                    <a href="{{ url_for('main.episode_detail', tmdb_id=show.tmdb_id, season_number=season.season_number, episode_number=episode.episode_number) }}" class="hover:underline">
+                                                        {{ episode.episode_number }}. {{ episode.title | default('TBA') }}
+                                                    </a>
                                                 </h4>
                                                 {% if episode.overview %}
                                                 <p class="text-sm text-gray-600 dark:text-gray-400 mt-1 line-clamp-2 hover:line-clamp-none transition-all duration-200 ease-in-out">

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,9 +27,10 @@ This document outlines the planned features and development stages for the ShowN
 - [x] **Logo Display Fixes:** Corrected display of Sonarr and Radarr logos on the `/admin/tasks` page for proper visibility in both light and dark modes.
 - [x] **Flask Route Modularization:** Refactored application routes into Admin (`/admin`) and Main blueprints for improved organization and maintainability.
 - [x] **Interactive Service Connection Testing:** Enhanced the Admin Services page to allow manual testing of service connections (Sonarr, Radarr, Bazarr, Ollama, Pushover) using current form values, with immediate visual feedback and resolution of related `url_for` and JavaScript issues.
+- [x] **Tautulli Integration:** Watch history synchronization via Tautulli API with connection testing.
+- [x] **Admin Logbook & User List:** Added logbook page and basic Plex user listing.
 
 ## Next Steps
-- [ ] **Tautulli Integration (Full):** Complete implementation of Tautulli watch history synchronization and API interaction (stubs currently in place).
 - [ ] Improve robustness of Plex user detection at login (handle edge cases, more reliable username/id capture)
 - [ ] Consider showing a more detailed history/list of recent events per user on a dedicated page.
 - [ ] Add more metadata from Sonarr/Radarr to homepage cards if needed (current display is quite rich).


### PR DESCRIPTION
## Summary
- implement Tautulli sync and connection tests
- store images to proper folders
- add episode detail pages and links
- add admin logbook and users list
- collapse service cards on settings page
- create DB migrations for Tautulli settings and user last login

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851cbcd23948321b9459147593cef62