### PR TITLE
Fix SQL syntax in admin settings update

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -141,8 +141,7 @@ def settings():
             sonarr_url=?, sonarr_api_key=?,
             bazarr_url=?, bazarr_api_key=?,
             ollama_url=?, pushover_key=?, pushover_token=?,
-            plex_client_id=?, tautulli_url=?, tautulli_api_key=?
-            WHERE id=?''', (
+            plex_client_id=?, tautulli_url=?, tautulli_api_key=? WHERE id=?''', (
             request.form.get('radarr_url'),
             request.form.get('radarr_api_key'),
             request.form.get('sonarr_url'),


### PR DESCRIPTION
## Summary
- patch UPDATE statement for settings so `WHERE id=?` is valid

## Testing
- `python3 - <<'PY'
import sqlite3
conn=sqlite3.connect(':memory:')
conn.execute('CREATE TABLE settings (id INTEGER PRIMARY KEY, radarr_url TEXT, radarr_api_key TEXT, sonarr_url TEXT, sonarr_api_key TEXT, bazarr_url TEXT, bazarr_api_key TEXT, ollama_url TEXT, pushover_key TEXT, pushover_token TEXT, plex_client_id TEXT, tautulli_url TEXT, tautulli_api_key TEXT)')
conn.execute('INSERT INTO settings (id) VALUES (1)')
try:
    conn.execute("""UPDATE settings SET radarr_url=?, radarr_api_key=?, sonarr_url=?, sonarr_api_key=?, bazarr_url=?, bazarr_api_key=?, ollama_url=?, pushover_key=?, pushover_token=?, plex_client_id=?, tautulli_url=?, tautulli_api_key=? WHERE id=?""", (1,1,1,1,1,1,1,1,1,1,1,1,1))
    print('no error')
except Exception as e:
    print('error', e)
PY

------
https://chatgpt.com/codex/tasks/task_e_6851d8bffbd083219c75cd336ae03574