### PR TITLE
Add weekly metrics to admin dashboard

### DIFF
--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -40,11 +40,25 @@
         </div>
         <div class="bg-slate-50 dark:bg-slate-700 p-4 rounded-lg shadow">
             <h3 class="text-lg font-medium text-slate-700 dark:text-slate-200">Movies in Radarr</h3>
-            <p class="text-3xl font-bold text-sky-600 dark:text-sky-400">{{ movie_count if movie_count is not none else '--' }}</p>
+            <p class="text-sm text-slate-600 dark:text-slate-300">Total:</p>
+            <p class="text-3xl font-bold text-sky-600 dark:text-sky-400 mb-2">{{ movie_count if movie_count is not none else '--' }}</p>
+            <p class="text-sm text-slate-600 dark:text-slate-300">This week:</p>
+            <p class="text-2xl font-semibold text-sky-600 dark:text-sky-400">{{ radarr_week_count if radarr_week_count is not none else '--' }}</p>
         </div>
         <div class="bg-slate-50 dark:bg-slate-700 p-4 rounded-lg shadow">
             <h3 class="text-lg font-medium text-slate-700 dark:text-slate-200">Shows in Sonarr</h3>
-            <p class="text-3xl font-bold text-sky-600 dark:text-sky-400">{{ show_count if show_count is not none else '--' }}</p>
+            <p class="text-sm text-slate-600 dark:text-slate-300">Total:</p>
+            <p class="text-3xl font-bold text-sky-600 dark:text-sky-400 mb-2">{{ show_count if show_count is not none else '--' }}</p>
+            <p class="text-sm text-slate-600 dark:text-slate-300">This week:</p>
+            <p class="text-2xl font-semibold text-sky-600 dark:text-sky-400">{{ sonarr_week_count if sonarr_week_count is not none else '--' }}</p>
+        </div>
+        <div class="bg-slate-50 dark:bg-slate-700 p-4 rounded-lg shadow">
+            <h3 class="text-lg font-medium text-slate-700 dark:text-slate-200">OpenAI Cost (7d)</h3>
+            <p class="text-3xl font-bold text-sky-600 dark:text-sky-400">${{ '%.5f'|format(openai_cost_week|float) if openai_cost_week is not none else '--' }}</p>
+        </div>
+        <div class="bg-slate-50 dark:bg-slate-700 p-4 rounded-lg shadow">
+            <h3 class="text-lg font-medium text-slate-700 dark:text-slate-200">Ollama Avg Time (ms, 7d)</h3>
+            <p class="text-3xl font-bold text-sky-600 dark:text-sky-400">{{ ollama_avg_ms|round|int if ollama_avg_ms is not none else '--' }}</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- show weekly Radarr and Sonarr counts on dashboard
- pull OpenAI cost and Ollama processing metrics from `api_usage`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685732b7b2b88321b734bced451bd532