### PR TITLE
Update admin dashboard and logs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from flask import Flask
 from flask_login import LoginManager
 from . import database
 from . import cli
-from .utils import format_datetime_simple # Added import for the filter
+from .utils import format_datetime_simple, format_milliseconds
 
 login_manager = LoginManager()
 
@@ -118,6 +118,7 @@ def create_app(test_config=None):
 
     # Register Jinja filters
     app.jinja_env.filters['format_datetime'] = format_datetime_simple
+    app.jinja_env.filters['format_ms'] = format_milliseconds
 
     app.logger.info('ShowNotes application successfully created.')
     return app

--- a/app/llm_services.py
+++ b/app/llm_services.py
@@ -41,7 +41,7 @@ def get_llm_response(prompt_text, llm_model_name=None, provider=None):
     ollama_url = get_setting("ollama_url")
 
     # Default model names (could be moved to settings or config file later)
-    default_openai_model = "gpt-3.5-turbo"
+    default_openai_model = get_setting("openai_model_name") or "gpt-3.5-turbo"
     # Use the admin-configured model if present, else fallback
     default_ollama_model = get_setting("ollama_model_name") or "llama2" # Make sure this model is available in the user's Ollama instance
 

--- a/app/migrations/012_add_openai_model_name_to_settings.py
+++ b/app/migrations/012_add_openai_model_name_to_settings.py
@@ -1,0 +1,23 @@
+import sqlite3
+import os
+
+INSTANCE_FOLDER_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'instance')
+DB_PATH = os.environ.get('SHOWNOTES_DB', os.path.join(INSTANCE_FOLDER_PATH, 'shownotes.sqlite3'))
+
+def upgrade():
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(settings)")
+    cols = [r[1] for r in cur.fetchall()]
+    if 'openai_model_name' not in cols:
+        cur.execute("ALTER TABLE settings ADD COLUMN openai_model_name TEXT")
+        print("Added openai_model_name column to settings table.")
+    else:
+        print("Column openai_model_name already exists in settings table.")
+    conn.commit()
+    conn.close()
+
+if __name__ == '__main__':
+    print("Running migration: 012_add_openai_model_name_to_settings.py")
+    upgrade()
+    print("Migration 012_add_openai_model_name_to_settings.py completed.")

--- a/app/templates/admin_api_usage_logs.html
+++ b/app/templates/admin_api_usage_logs.html
@@ -7,34 +7,69 @@
 {% block admin_page_content %}
 <div class="bg-white dark:bg-slate-800 shadow-lg rounded-sm border border-slate-200 dark:border-slate-700 p-4 sm:p-6">
     <h2 class="text-xl font-semibold text-slate-800 dark:text-slate-100 mb-4">API Usage Details</h2>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+        <div class="bg-slate-100 dark:bg-slate-700 p-3 rounded">
+            <p class="text-sm text-slate-600 dark:text-slate-300">Total Cost</p>
+            <p class="text-lg font-semibold">${{ '%.5f'|format(total_cost|float) }}</p>
+        </div>
+        <div class="bg-slate-100 dark:bg-slate-700 p-3 rounded">
+            <p class="text-sm text-slate-600 dark:text-slate-300">Cost (7d)</p>
+            <p class="text-lg font-semibold">${{ '%.5f'|format(week_cost|float) }}</p>
+        </div>
+        <div class="bg-slate-100 dark:bg-slate-700 p-3 rounded">
+            <p class="text-sm text-slate-600 dark:text-slate-300">OpenAI Calls</p>
+            <p class="text-lg font-semibold">{{ openai_count }}</p>
+        </div>
+        <div class="bg-slate-100 dark:bg-slate-700 p-3 rounded">
+            <p class="text-sm text-slate-600 dark:text-slate-300">Ollama Calls</p>
+            <p class="text-lg font-semibold">{{ ollama_count }}</p>
+        </div>
+    </div>
+
+    <form method="get" class="flex flex-wrap gap-2 mb-4">
+        <select name="provider" class="border rounded p-1 text-sm">
+            <option value="">All Providers</option>
+            <option value="openai" {% if provider_filter=='openai' %}selected{% endif %}>OpenAI</option>
+            <option value="ollama" {% if provider_filter=='ollama' %}selected{% endif %}>Ollama</option>
+        </select>
+        <input type="date" name="start_date" value="{{ start_date }}" class="border rounded p-1 text-sm">
+        <input type="date" name="end_date" value="{{ end_date }}" class="border rounded p-1 text-sm">
+        <button type="submit" class="bg-sky-500 hover:bg-sky-600 text-white px-3 py-1 rounded text-sm">Filter</button>
+    </form>
+
     {% if logs %}
     <div class="overflow-x-auto">
-        <table class="w-full table-auto">
+        <table class="w-full table-auto" id="usage-table">
             <thead class="text-xs font-semibold uppercase text-slate-500 dark:text-slate-400 bg-slate-50 dark:bg-slate-700/20">
                 <tr>
-                    <th class="p-2 whitespace-nowrap"><div class="font-semibold text-left">ID</div></th>
-                    <th class="p-2 whitespace-nowrap"><div class="font-semibold text-left">Timestamp</div></th>
-                    <th class="p-2 whitespace-nowrap"><div class="font-semibold text-left">Provider</div></th>
-                    <th class="p-2 whitespace-nowrap"><div class="font-semibold text-left">Endpoint</div></th>
-                    <th class="p-2 whitespace-nowrap"><div class="font-semibold text-right">Prompt Tokens</div></th>
-                    <th class="p-2 whitespace-nowrap"><div class="font-semibold text-right">Completion Tokens</div></th>
-                    <th class="p-2 whitespace-nowrap"><div class="font-semibold text-right">Total Tokens</div></th>
-                    <th class="p-2 whitespace-nowrap"><div class="font-semibold text-right">Processing Time (ms)</div></th>
-                    <th class="p-2 whitespace-nowrap"><div class="font-semibold text-right">Cost (USD)</div></th>
+                    <th class="p-2 text-left cursor-pointer">Date</th>
+                    <th class="p-2 text-left cursor-pointer">Provider</th>
+                    <th class="p-2 text-left">Endpoint</th>
+                    <th class="p-2 text-right cursor-pointer">Prompt</th>
+                    <th class="p-2 text-right cursor-pointer">Completion</th>
+                    <th class="p-2 text-right cursor-pointer">Total</th>
+                    <th class="p-2 text-right cursor-pointer">Time</th>
+                    <th class="p-2 text-right cursor-pointer">Cost</th>
                 </tr>
             </thead>
             <tbody class="text-sm divide-y divide-slate-100 dark:divide-slate-700">
                 {% for log_entry in logs %}
                 <tr>
-                    <td class="p-2 whitespace-nowrap"><div class="text-left">{{ log_entry.id }}</div></td>
-                    <td class="p-2 whitespace-nowrap"><div class="text-left">{{ log_entry.timestamp.strftime('%Y-%m-%d %H:%M:%S') if log_entry.timestamp else 'N/A' }}</div></td>
-                    <td class="p-2 whitespace-nowrap"><div class="text-left">{{ log_entry.provider if log_entry.provider else '-' }}</div></td>
-                    <td class="p-2 whitespace-nowrap"><div class="text-left">{{ log_entry.endpoint }}</div></td>
-                    <td class="p-2 whitespace-nowrap"><div class="text-right">{{ log_entry.prompt_tokens if log_entry.prompt_tokens is not none else '-' }}</div></td>
-                    <td class="p-2 whitespace-nowrap"><div class="text-right">{{ log_entry.completion_tokens if log_entry.completion_tokens is not none else '-' }}</div></td>
-                    <td class="p-2 whitespace-nowrap"><div class="text-right">{{ log_entry.total_tokens if log_entry.total_tokens is not none else '-' }}</div></td>
-                    <td class="p-2 whitespace-nowrap"><div class="text-right">{{ log_entry.processing_time_ms if log_entry.processing_time_ms is not none else '-' }}</div></td>
-                    <td class="p-2 whitespace-nowrap"><div class="text-right">${{ "%.5f"|format(log_entry.cost_usd|float) if log_entry.cost_usd is not none else '-' }}</div></td>
+                    <td class="p-2" title="{{ log_entry.timestamp.strftime('%Y-%m-%d %H:%M:%S') if log_entry.timestamp else '' }}">{{ log_entry.timestamp.strftime('%Y-%m-%d') if log_entry.timestamp else 'N/A' }}</td>
+                    <td class="p-2">
+                        {% if log_entry.provider == 'openai' %}
+                        <svg class="w-4 h-4 inline" viewBox="0 0 40.81 40.81" xmlns="http://www.w3.org/2000/svg"><path d="M38.08,0H2.73A2.73,2.73,0,0,0,0,2.73V38.08a2.73,2.73,0,0,0,2.73,2.73H38.08a2.73,2.73,0,0,0,2.73-2.73V2.73A2.73,2.73,0,0,0,38.08,0ZM29.2,16.52a7.2,7.2,0,0,1-2,.32,7.33,7.33,0,0,1-5.48-2.1,7.21,7.21,0,0,1-1.89-5.11,7.48,7.48,0,0,1,2.23-5.51A7.31,7.31,0,0,1,22,2.73a7.2,7.2,0,0,1,5.23,1.88,7.48,7.48,0,0,1,2,5.63,7.21,7.21,0,0,1-1.89,5.11A7.33,7.33,0,0,1,29.2,16.52Zm-7.68,4.66a7.31,7.31,0,0,1,5.23,1.88,7.48,7.48,0,0,1,2,5.63,7.21,7.21,0,0,1-1.89,5.11,7.33,7.33,0,0,1-5.48,2.1,7.2,7.2,0,0,1-2-.32,7.33,7.33,0,0,1-5.48-2.1,7.21,7.21,0,0,1-1.89-5.11,7.48,7.48,0,0,1,2.23-5.51A7.31,7.31,0,0,1,16.29,20a7.2,7.2,0,0,1,5.23,1.18ZM11.61,24.27a7.2,7.2,0,0,1-2,.32,7.33,7.33,0,0,1-5.48-2.1A7.21,7.21,0,0,1,2.26,17.4a7.48,7.48,0,0,1,2.23-5.51A7.31,7.31,0,0,1,9.36,10.7a7.2,7.2,0,0,1,5.23,1.88,7.48,7.48,0,0,1,2,5.63,7.21,7.21,0,0,1-1.89,5.11A7.33,7.33,0,0,1,11.61,24.27Zm15.21-4.66a7.31,7.31,0,0,1-5.23-1.88,7.48,7.48,0,0,1-2-5.63,7.21,7.21,0,0,1,1.89-5.11A7.33,7.33,0,0,1,21.52,6a7.2,7.2,0,0,1,2,.32,7.33,7.33,0,0,1,5.48,2.1,7.21,7.21,0,0,1,1.89,5.11,7.48,7.48,0,0,1-2.23,5.51A7.31,7.31,0,0,1,24.71,20.79a7.2,7.2,0,0,1-5.23-1.18Z" fill="currentColor"/></svg>
+                        {% else %}
+                        <img src="{{ url_for('static', filename='logos/ollama-light.png') }}" alt="ollama" class="w-4 h-4 inline dark:hidden"><img src="{{ url_for('static', filename='logos/ollama-dark.png') }}" alt="ollama" class="w-4 h-4 inline hidden dark:inline">
+                        {% endif %}
+                    </td>
+                    <td class="p-2">{{ log_entry.endpoint }}</td>
+                    <td class="p-2 text-right">{{ log_entry.prompt_tokens if log_entry.prompt_tokens is not none else '-' }}</td>
+                    <td class="p-2 text-right">{{ log_entry.completion_tokens if log_entry.completion_tokens is not none else '-' }}</td>
+                    <td class="p-2 text-right">{{ log_entry.total_tokens if log_entry.total_tokens is not none else '-' }}</td>
+                    <td class="p-2 text-right">{{ log_entry.processing_time_ms|format_ms if log_entry.processing_time_ms is not none else '-' }}</td>
+                    <td class="p-2 text-right">${{ "%.5f"|format(log_entry.cost_usd|float) if log_entry.cost_usd is not none else '-' }}</td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -44,4 +79,21 @@
     <p class="text-center text-slate-500 dark:text-slate-400 py-8">No API usage logs found.</p>
     {% endif %}
 </div>
+
+<script>
+// Basic column sorting
+document.querySelectorAll('#usage-table th').forEach(function(th, idx){
+  th.addEventListener('click', function(){
+    const table = th.closest('table');
+    const rows = Array.from(table.querySelectorAll('tbody tr'));
+    const asc = th.classList.toggle('asc');
+    rows.sort(function(a,b){
+      const aText = a.children[idx].textContent.trim();
+      const bText = b.children[idx].textContent.trim();
+      return asc ? aText.localeCompare(bText, undefined, {numeric:true}) : bText.localeCompare(aText, undefined, {numeric:true});
+    });
+    rows.forEach(r => table.tBodies[0].appendChild(r));
+  });
+});
+</script>
 {% endblock %}

--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -53,12 +53,14 @@
             <p class="text-2xl font-semibold text-sky-600 dark:text-sky-400">{{ sonarr_week_count if sonarr_week_count is not none else '--' }}</p>
         </div>
         <div class="bg-slate-50 dark:bg-slate-700 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-slate-700 dark:text-slate-200">OpenAI Cost (7d)</h3>
-            <p class="text-3xl font-bold text-sky-600 dark:text-sky-400">${{ '%.5f'|format(openai_cost_week|float) if openai_cost_week is not none else '--' }}</p>
+            <h3 class="text-lg font-medium text-slate-700 dark:text-slate-200">OpenAI Usage (7d)</h3>
+            <p class="text-sm text-slate-600 dark:text-slate-300">Calls: {{ openai_call_count_week }}</p>
+            <p class="text-2xl font-semibold text-sky-600 dark:text-sky-400">${{ '%.5f'|format(openai_cost_week|float) if openai_cost_week is not none else '--' }}</p>
         </div>
         <div class="bg-slate-50 dark:bg-slate-700 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-slate-700 dark:text-slate-200">Ollama Avg Time (ms, 7d)</h3>
-            <p class="text-3xl font-bold text-sky-600 dark:text-sky-400">{{ ollama_avg_ms|round|int if ollama_avg_ms is not none else '--' }}</p>
+            <h3 class="text-lg font-medium text-slate-700 dark:text-slate-200">Ollama Avg Time (7d)</h3>
+            <p class="text-sm text-slate-600 dark:text-slate-300">Calls: {{ ollama_call_count_week }}</p>
+            <p class="text-2xl font-semibold text-sky-600 dark:text-sky-400">{{ ollama_avg_ms|format_ms if ollama_avg_ms is not none else '--' }}</p>
         </div>
     </div>
 </div>

--- a/app/templates/admin_settings.html
+++ b/app/templates/admin_settings.html
@@ -38,7 +38,7 @@
                     <label class="block text-sm font-medium text-slate-700 dark:text-slate-200" for="ollama_url">Ollama URL</label>
                     <span id="ollama_status_dot" class="ml-auto {% if ollama_status %}text-green-500{% else %}text-red-500{% endif %}" title="{% if ollama_status %}Connected{% else %}Not Connected/Error{% endif %}">●</span>
                 </div>
-                <input type="text" id="ollama_url" name="ollama_url" value="{{ settings.ollama_url or '' }}" placeholder="e.g., http://localhost:11434" class="border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 text-slate-900 dark:text-slate-50 rounded-lg p-2 w-full focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500">
+                <input type="url" id="ollama_url" name="ollama_url" autocomplete="off" value="{{ settings.ollama_url or '' }}" placeholder="e.g., http://localhost:11434" class="border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 text-slate-900 dark:text-slate-50 rounded-lg p-2 w-full focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500">
                  <button type="button" data-service="ollama" class="test-btn bg-sky-500 hover:bg-sky-600 text-white px-4 py-2 rounded-md shadow-sm mt-2 text-xs font-medium">Test Ollama</button>
                 <p class="text-xs text-slate-500 dark:text-slate-400 mt-1">URL for your self-hosted Ollama instance. Required if Ollama is the preferred provider.</p>
                 <div id="ollama-model-select-container" class="mt-2">
@@ -60,8 +60,14 @@
                     <svg class="w-5 h-5 object-contain text-slate-700 dark:text-slate-300" viewBox="0 0 40.81 40.81" xmlns="http://www.w3.org/2000/svg"><path d="M38.08,0H2.73A2.73,2.73,0,0,0,0,2.73V38.08a2.73,2.73,0,0,0,2.73,2.73H38.08a2.73,2.73,0,0,0,2.73-2.73V2.73A2.73,2.73,0,0,0,38.08,0ZM29.2,16.52a7.2,7.2,0,0,1-2,.32,7.33,7.33,0,0,1-5.48-2.1,7.21,7.21,0,0,1-1.89-5.11,7.48,7.48,0,0,1,2.23-5.51A7.31,7.31,0,0,1,22,2.73a7.2,7.2,0,0,1,5.23,1.88,7.48,7.48,0,0,1,2,5.63,7.21,7.21,0,0,1-1.89,5.11A7.33,7.33,0,0,1,29.2,16.52Zm-7.68,4.66a7.31,7.31,0,0,1,5.23,1.88,7.48,7.48,0,0,1,2,5.63,7.21,7.21,0,0,1-1.89,5.11,7.33,7.33,0,0,1-5.48,2.1,7.2,7.2,0,0,1-2-.32,7.33,7.33,0,0,1-5.48-2.1,7.21,7.21,0,0,1-1.89-5.11,7.48,7.48,0,0,1,2.23-5.51A7.31,7.31,0,0,1,16.29,20a7.2,7.2,0,0,1,5.23,1.18ZM11.61,24.27a7.2,7.2,0,0,1-2,.32,7.33,7.33,0,0,1-5.48-2.1A7.21,7.21,0,0,1,2.26,17.4a7.48,7.48,0,0,1,2.23-5.51A7.31,7.31,0,0,1,9.36,10.7a7.2,7.2,0,0,1,5.23,1.88,7.48,7.48,0,0,1,2,5.63,7.21,7.21,0,0,1-1.89,5.11A7.33,7.33,0,0,1,11.61,24.27Zm15.21-4.66a7.31,7.31,0,0,1-5.23-1.88,7.48,7.48,0,0,1-2-5.63,7.21,7.21,0,0,1,1.89-5.11A7.33,7.33,0,0,1,21.52,6a7.2,7.2,0,0,1,2,.32,7.33,7.33,0,0,1,5.48,2.1,7.21,7.21,0,0,1,1.89,5.11,7.48,7.48,0,0,1-2.23,5.51A7.31,7.31,0,0,1,24.71,20.79a7.2,7.2,0,0,1-5.23-1.18Z" fill="currentColor"/></svg>
                     <label class="block text-sm font-medium text-slate-700 dark:text-slate-200" for="openai_api_key">OpenAI API Key</label>
                 </div>
-                <input type="password" id="openai_api_key" name="openai_api_key" value="{{ settings.openai_api_key or '' }}" class="border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 text-slate-900 dark:text-slate-50 rounded-lg p-2 w-full focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500">
+                <input type="password" id="openai_api_key" name="openai_api_key" autocomplete="off" value="{{ settings.openai_api_key or '' }}" class="border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 text-slate-900 dark:text-slate-50 rounded-lg p-2 w-full focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500">
                 <p class="text-xs text-slate-500 dark:text-slate-400 mt-1">Your API key for OpenAI services. Required if OpenAI is the preferred provider.</p>
+                <label class="block text-sm font-medium text-slate-700 dark:text-slate-200 mt-3" for="openai_model_name">Model</label>
+                <select id="openai_model_name" name="openai_model_name" class="border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 text-slate-900 dark:text-slate-50 rounded-lg p-2 w-full focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500">
+                    {% for m in openai_models %}
+                    <option value="{{ m.name }}" {% if settings.openai_model_name == m.name %}selected{% endif %}>{{ m.name }} ({{ m.price }})</option>
+                    {% endfor %}
+                </select>
             </div>
         </div>
     </details>

--- a/app/utils.py
+++ b/app/utils.py
@@ -1308,6 +1308,18 @@ def format_datetime_simple(value, format_str='%b %d, %Y %H:%M'):
         return dt_obj.strftime(format_str)
     return value # Should not be reached if logic is correct, but as a fallback
 
+def format_milliseconds(value):
+    """Format a millisecond duration as ``MM:SS.mmm``."""
+    if value is None:
+        return ""
+    try:
+        ms = int(value)
+        seconds, milliseconds = divmod(ms, 1000)
+        minutes, seconds = divmod(seconds, 60)
+        return f"{minutes:02d}:{seconds:02d}.{milliseconds:03d}"
+    except Exception:
+        return str(value)
+
 # --- Tautulli Stubs ---
 
 def sync_tautulli_watch_history():


### PR DESCRIPTION
## Summary
- format MS durations with `format_ms`
- show API call counts and nicely formatted times on the admin dashboard
- add summary, filters and sortable columns on API usage logs
- disable autocomplete on Ollama URL and add OpenAI model dropdown
- support storing OpenAI model name in settings

## Testing
- `python -m py_compile app/utils.py app/__init__.py app/routes/admin.py app/llm_services.py app/migrations/012_add_openai_model_name_to_settings.py`

------
https://chatgpt.com/codex/tasks/task_e_68573804bc08832198a9e12d81ead6ee